### PR TITLE
Whitespace cleanup and changed descriptions to be more assertive

### DIFF
--- a/spec/agency_spec.rb
+++ b/spec/agency_spec.rb
@@ -5,37 +5,37 @@ describe FederalRegister::Agency do
     before(:each) do
       FakeWeb.register_uri(:get, "http://www.federalregister.gov/api/v1/agencies.json", :body => [{},{}].to_json, :content_type =>"text/json")
     end
-    
+
     it "returns Agency objects" do
       agencies = FederalRegister::Agency.all
       agencies.each do |agency|
         agency.should be_an_instance_of(FederalRegister::Agency)
       end
     end
-    
+
     it "returns multiple agencies" do
       agencies = FederalRegister::Agency.all
       agencies.count.should == 2
     end
   end
-  
+
   describe "attribute loading" do
     before(:each) do
       @agency = FederalRegister::Agency.new({'name' => "Commerce Department", 'json_url' => "http://www.federalregister.gov/api/v1/agencies/1.json"})
     end
-    
+
     describe "existing attribute" do
       it "reads the from the json hash if already there" do
         @agency.name.should == 'Commerce Department'
       end
     end
-  
+
     describe "non-existent attributes" do
       it "should trigger an error" do
         lambda {@agency.non_existent_attribute}.should raise_error NoMethodError
       end
     end
-    
+
     describe "missing attribute" do
       FakeWeb.register_uri(:get, "http://www.federalregister.gov/api/v1/agencies/1.json", :body => {:description => "Lorem ipsum"}.to_json, :content_type =>"text/json")
       it "should lazy-load from the json_url" do
@@ -44,7 +44,7 @@ describe FederalRegister::Agency do
         @agency.send(:attributes)['description'].should == "Lorem ipsum"
       end
     end
-    
+
     describe "missing attribute when no full json" do
       it "should lazy-load from the json_url" do
         @agency = FederalRegister::Agency.new({'name' => "Commerce Department"})

--- a/spec/article_spec.rb
+++ b/spec/article_spec.rb
@@ -2,7 +2,7 @@ require File.dirname(__FILE__) + '/spec_helper'
 
 describe FederalRegister::Article do
   describe ".find" do
-    it "should fetch the document by its document number" do
+    it "fetches the document by its document number" do
       document_number = "2010-213"
       FakeWeb.register_uri(
         :get,
@@ -10,11 +10,11 @@ describe FederalRegister::Article do
         :content_type =>"text/json",
         :body => {:title => "Important Notice"}.to_json
       )
-      
+
       FederalRegister::Article.find(document_number).title.should == 'Important Notice'
     end
-    
-    it "should throw an error when a document doesn't exist" do
+
+    it "throws an error when a document doesn't exist" do
       document_number = "some-random-document"
       FakeWeb.register_uri(
         :get,
@@ -25,7 +25,7 @@ describe FederalRegister::Article do
       lambda{ FederalRegister::Article.find(document_number) }.should raise_error FederalRegister::Client::RecordNotFound
     end
   end
-  
+
   describe ".search" do
     before(:each) do
       FakeWeb.register_uri(
@@ -35,8 +35,8 @@ describe FederalRegister::Article do
         :body => {:count => 3}.to_json
       )
     end
-    
-    it "should return a resultset object" do
+
+    it "returns a resultset object" do
       FederalRegister::Article.search(:conditions => {:term => "Fish"}).should be_an_instance_of(FederalRegister::ResultSet)
     end
   end

--- a/spec/result_set_spec.rb
+++ b/spec/result_set_spec.rb
@@ -2,7 +2,7 @@ require File.dirname(__FILE__) + '/spec_helper'
 
 describe FederalRegister::ResultSet do
   describe "#next" do
-    it "should load the next_page_url" do
+    it "loads the next_page_url" do
       FakeWeb.register_uri(:get, "http://www.federalregister.gov/api/v1/fishes?page=2", :body => {:count => 24}.to_json, :content_type =>"text/json")
       FederalRegister::ResultSet.new({'next_page_url' => 'http://www.federalregister.gov/api/v1/fishes?page=2'}, FederalRegister::Article).next.count.should == 24
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,5 +13,5 @@ FakeWeb.allow_net_connect = false
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
 
 # RSpec.configure do |config|
-#   
+#
 # end


### PR DESCRIPTION
Some whitespace existed in the tests and I changed the expected result descriptions to be more assertive to align with recent shifts in best practices (avoiding "should").
