### PR TITLE
Specs for type casting

### DIFF
--- a/lib/federal_register/base.rb
+++ b/lib/federal_register/base.rb
@@ -11,7 +11,7 @@ class FederalRegister::Base < FederalRegister::Client
     attributes.each do |attr|
       define_method attr do
         val = @attributes[attr.to_s]
-        if val && options[:type] == :date
+        if val && options[:type] == :date && ! val.is_a?(Date)
           val = Date.strptime(val.to_s)
         end
 

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -21,6 +21,48 @@ describe FederalRegister::Base do
       )
       instance.foo.should == 'bar'
     end
+
+    context "when attribute is of type date" do
+      before(:each) do
+        @klass = Class.new(FederalRegister::Base)
+        @klass.add_attribute(:panda, :type => :date)
+      end
+
+      context "when value is nil" do
+        it "should return nil" do
+          instance = @klass.new('panda' => nil)
+          instance.panda.should be_nil
+        end
+      end
+
+      context "when value is a Date" do
+        it "returns a date" do
+          date = Date.today
+          instance = @klass.new('panda' => Date.today)
+          instance.panda.should == Date.today
+        end
+      end
+
+      context "when value is not a date" do
+        context "when value is a valid date string" do
+          it "returns the date" do
+            date_string = Date.today.to_s
+            instance = @klass.new('panda' => date_string)
+            instance.panda.should == Date.strptime(date_string)
+          end
+        end
+
+        context "when value is not a valid date string" do
+          it "throws" do
+            date_string = "PANDA"
+            instance = @klass.new('panda' => date_string)
+            lambda {
+              instance.panda.should == "never going to get here"
+            }.should raise_error
+          end
+        end
+      end
+    end
   end
 
   describe '.override_base_uri' do


### PR DESCRIPTION
Specs for type casting of dates because of a bug in the API. I thought it was in the gem so tried to write specs to reproduce it but it is actually in the data returned from the API.

The effective_on attribute is not a date object! It's actually this:

> article.instance_variable_get('@attributes')['effective_on']
> {"place_id"=>nil, "entry_id"=>568141, "title"=>"Modifications of Certain Derivative Contracts; Correction", "delta"=>false, "remote_call_in
> _available"=>nil, "id"=>413030, "date"=>Fri, 19 Aug 2011, "event_type"=>"EffectiveDate"}

It took some weirdness with the debugger but it worked. I can actually fix this with a custom getter but I'm not sure if that's how you want to approach this issue or not. Let me know and I'll be happy to add the method with nil checking and specs after you merge in these specs.
